### PR TITLE
Dockerfile: Fix path to binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ WORKDIR /app
 
 COPY . .
 
-RUN go mod tidy
+RUN go mod tidy && \
+    cd cmd/reddit-migrate && \
+    go build . && \
+    mv reddit-migrate ../../
 
 ENV GO_ADDR=":5005"
-ENTRYPOINT [ "go", "run", "." ]
+ENTRYPOINT ["./reddit-migrate"]
 
 EXPOSE 5005


### PR DESCRIPTION
Hi,

I've tried to use the Dockerfile to build and run my own binary, but the image was producing the following error message on startup:

```
no Go files in /app
```

I figured out this was because the binary has been moved to a different directory. I've updated the path to the binary in the Dockerfile and it works now.

Note that I've switched to doing a separate `go build` step, for two reasons:

1. Trying `go run` in the `cmd/reddit-migrate` directory produced other errors, related to missing assets.
2. This way the compilation is done as part of the the build process and can be reused across different container runs, and the start-up is instant.

Thanks for your work on this project. It worked well for me!