### PR TITLE
fix(codeowners): replace literal \n with real newlines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+# Code owners\n* @Arvuno

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-# Code owners\n* @Arvuno
+# Code owners
+* @Arvuno

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/Arvuno/reddit-migrate/actions/workflows/ci.yml/badge.svg)](https://github.com/Arvuno/reddit-migrate/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/nileshnk/reddit-migrate/release.yml?label=build)](https://github.com/nileshnk/reddit-migrate/actions)
 [![GitHub all releases](https://img.shields.io/github/downloads/nileshnk/reddit-migrate/total?label=downloads)](https://github.com/nileshnk/reddit-migrate/releases)


### PR DESCRIPTION
The current `.github/CODEOWNERS` file contains a literal `\n` sequence on line 1 instead of an actual newline. Fix: rewrite with LF newlines. Detected by CodeRabbit AI.